### PR TITLE
Migrate to Cetmodules 3.12.00 and modern CMake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,128 @@
+{
+   "configurePresets" : [
+      {
+         "cacheVariables" : {
+            "CMAKE_BUILD_TYPE" : {
+               "type" : "STRING",
+               "value" : "RelWithDebInfo"
+            },
+            "CMAKE_CXX_EXTENSIONS" : {
+               "type" : "BOOL",
+               "value" : "OFF"
+            },
+            "CMAKE_CXX_STANDARD_REQUIRED" : {
+               "type" : "BOOL",
+               "value" : "ON"
+            },
+            "larvecutils_ADD_ARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "LIBRARY_DIR"
+            },
+            "larvecutils_ADD_NOARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "INCLUDE_DIR"
+            },
+            "larvecutils_INCLUDE_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "include"
+            },
+            "larvecutils_LIBRARY_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "lib"
+            }
+         },
+         "description" : "Configuration settings translated from ups/product_deps",
+         "displayName" : "Configuration from product_deps",
+         "hidden" : true,
+         "name" : "from_product_deps"
+      },
+      {
+         "cacheVariables" : {
+            "CMAKE_CXX_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER}"
+            },
+            "CMAKE_CXX_STANDARD" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_STANDARD}"
+            },
+            "CMAKE_C_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER}"
+            },
+            "CMAKE_Fortran_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER}"
+            },
+            "UPS_CXX_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_ID}"
+            },
+            "UPS_CXX_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_VERSION}"
+            },
+            "UPS_C_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_ID}"
+            },
+            "UPS_C_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_VERSION}"
+            },
+            "UPS_Fortran_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_ID}"
+            },
+            "UPS_Fortran_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_VERSION}"
+            },
+            "WANT_UPS" : {
+               "type" : "BOOL",
+               "value" : true
+            },
+            "larvecutils_EXEC_PREFIX_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FQ_DIR}"
+            },
+            "larvecutils_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
+               "type" : "STRING",
+               "value" : "cetmodules"
+            },
+            "larvecutils_UPS_PRODUCT_FLAVOR_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FLAVOR}"
+            },
+            "larvecutils_UPS_PRODUCT_NAME_INIT" : {
+               "type" : "STRING",
+               "value" : "larvecutils"
+            },
+            "larvecutils_UPS_QUALIFIER_STRING_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_QUALSPEC}"
+            }
+         },
+         "description" : "Extra configuration for UPS package generation",
+         "displayName" : "UPS extra configuration",
+         "hidden" : true,
+         "name" : "extra_for_UPS"
+      },
+      {
+         "description" : "Default configuration including settings from ups/product_deps",
+         "displayName" : "Default configuration",
+         "inherits" : "from_product_deps",
+         "name" : "default"
+      },
+      {
+         "description" : "Default configuration for UPS package generation",
+         "displayName" : "Default configuration for UPS",
+         "inherits" : [
+            "default",
+            "extra_for_UPS"
+         ],
+         "name" : "for_UPS"
+      }
+   ],
+   "version" : 3
+}

--- a/larvecutils/MarqFitAlg/CMakeLists.txt
+++ b/larvecutils/MarqFitAlg/CMakeLists.txt
@@ -1,4 +1,6 @@
-cet_make_library(LIBRARY_NAME_VAR libtarget  SOURCE MarqFitAlg.cxx )
+cet_make_library(LIBRARY_NAME_VAR libtarget
+  SOURCE MarqFitAlg.cxx
+)
 
 if( ${CMAKE_HOST_SYSTEM_VERSION} MATCHES "^2.6.32.*" )
   # even if OpenMP is found on a SLF6 machine, it cannot be used.

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,8 +248,9 @@ libdir	fq_dir		lib
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-clang		v7_0_0		-
-gcc		v9_3_0		-
+clang		v7_0_0		c7
+gcc		v8_2_0		e19
+gcc		v9_3_0		e20
 cetmodules	v3_06_01	-	only_for_build
 end_product_list
 ####################################
@@ -305,11 +306,11 @@ end_product_list
 #   case it is optional.
 #
 ####################################
-qualifier	gcc	clang	notes
-c7:debug	-	-nq-
-c7:prof		-	-nq-
-e20:debug	-nq-	-
-e20:prof	-nq-	-
+qualifier	clang	gcc	compiler	notes
+c7:debug	-nq-	-	clang
+c7:prof		-nq-	-	clang
+e20:debug	-	-nq-	gcc
+e20:prof	-	-nq-	gcc
 end_qualifier_list
 ####################################
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -251,7 +251,7 @@ product		version		qual	flags		<table_format=2>
 clang		v7_0_0		c7
 gcc		v8_2_0		e19
 gcc		v9_3_0		e20
-cetmodules	v3_06_01	-	only_for_build
+cetmodules	v3_12_00	-	only_for_build
 end_product_list
 ####################################
 


### PR DESCRIPTION
- Fix compiler handling in ups/product_deps
- Minor formatting for readability and scripted dependency checking
- Cetmodules -> 3.12.00
- Presets generated by Cetmodules 3.12.00
